### PR TITLE
Remoção do campo Otros Títulos da base Latindex ao montar base de correção

### DIFF
--- a/mount_primary_base.py
+++ b/mount_primary_base.py
@@ -19,7 +19,7 @@ BASE2COLUMN_INDEXES = {
         },
         'latindex': {
             'issn': [0],
-            'title': [2, 4, 5],
+            'title': [2, 5],
             'sep': '\t',
             'country': 3,
         },


### PR DESCRIPTION
Exclui da montagem da base de correção primária o campo "Otros Títulos" da fonte de dados Latindex.